### PR TITLE
Add bank list retrieval endpoint

### DIFF
--- a/mstockRestAPI/mstockRestAPI/src/main/java/com/mstockRestAPI/mstockRestAPI/controller/BankController.java
+++ b/mstockRestAPI/mstockRestAPI/src/main/java/com/mstockRestAPI/mstockRestAPI/controller/BankController.java
@@ -1,0 +1,32 @@
+package com.mstockRestAPI.mstockRestAPI.controller;
+
+import com.mstockRestAPI.mstockRestAPI.dto.BankDto;
+import com.mstockRestAPI.mstockRestAPI.service.BankService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/banks")
+public class BankController {
+
+    private final BankService bankService;
+
+    @Autowired
+    public BankController(BankService bankService){
+        this.bankService = bankService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<BankDto>> getAll(){
+        return new ResponseEntity<>(
+                bankService.getAll(),
+                HttpStatus.OK
+        );
+    }
+}

--- a/mstockRestAPI/mstockRestAPI/src/main/java/com/mstockRestAPI/mstockRestAPI/dto/BankDto.java
+++ b/mstockRestAPI/mstockRestAPI/src/main/java/com/mstockRestAPI/mstockRestAPI/dto/BankDto.java
@@ -1,0 +1,25 @@
+package com.mstockRestAPI.mstockRestAPI.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+public class BankDto {
+
+    private Long id;
+
+    @NotBlank(message = "Bank name is required")
+    private String bankName;
+
+    @Min(value = 0, message = "isActive must be 0 or 1")
+    @Max(value = 1, message = "isActive must be 0 or 1")
+    @Builder.Default
+    private byte isActive = 1;
+}

--- a/mstockRestAPI/mstockRestAPI/src/main/java/com/mstockRestAPI/mstockRestAPI/entity/Bank.java
+++ b/mstockRestAPI/mstockRestAPI/src/main/java/com/mstockRestAPI/mstockRestAPI/entity/Bank.java
@@ -1,0 +1,26 @@
+package com.mstockRestAPI.mstockRestAPI.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "banks")
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Bank extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "bankName", nullable = false, unique = true)
+    private String bankName;
+
+    @Column(name = "isActive", columnDefinition = "TINYINT DEFAULT 1")
+    @Builder.Default
+    private Byte isActive = 1;
+}

--- a/mstockRestAPI/mstockRestAPI/src/main/java/com/mstockRestAPI/mstockRestAPI/repository/BankRepository.java
+++ b/mstockRestAPI/mstockRestAPI/src/main/java/com/mstockRestAPI/mstockRestAPI/repository/BankRepository.java
@@ -1,0 +1,7 @@
+package com.mstockRestAPI.mstockRestAPI.repository;
+
+import com.mstockRestAPI.mstockRestAPI.entity.Bank;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BankRepository extends JpaRepository<Bank, Long> {
+}

--- a/mstockRestAPI/mstockRestAPI/src/main/java/com/mstockRestAPI/mstockRestAPI/service/BankService.java
+++ b/mstockRestAPI/mstockRestAPI/src/main/java/com/mstockRestAPI/mstockRestAPI/service/BankService.java
@@ -1,0 +1,9 @@
+package com.mstockRestAPI.mstockRestAPI.service;
+
+import com.mstockRestAPI.mstockRestAPI.dto.BankDto;
+
+import java.util.List;
+
+public interface BankService {
+    List<BankDto> getAll();
+}

--- a/mstockRestAPI/mstockRestAPI/src/main/java/com/mstockRestAPI/mstockRestAPI/service/impl/BankServiceImpl.java
+++ b/mstockRestAPI/mstockRestAPI/src/main/java/com/mstockRestAPI/mstockRestAPI/service/impl/BankServiceImpl.java
@@ -1,0 +1,32 @@
+package com.mstockRestAPI.mstockRestAPI.service.impl;
+
+import com.mstockRestAPI.mstockRestAPI.dto.BankDto;
+import com.mstockRestAPI.mstockRestAPI.entity.Bank;
+import com.mstockRestAPI.mstockRestAPI.payload.converter.Converter;
+import com.mstockRestAPI.mstockRestAPI.repository.BankRepository;
+import com.mstockRestAPI.mstockRestAPI.service.BankService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class BankServiceImpl implements BankService {
+
+    private final BankRepository bankRepository;
+    private final Converter converter;
+
+    @Autowired
+    public BankServiceImpl(BankRepository bankRepository, Converter converter){
+        this.bankRepository = bankRepository;
+        this.converter = converter;
+    }
+
+    @Override
+    public List<BankDto> getAll() {
+        List<Bank> bankList = bankRepository.findAll();
+        return bankList.stream().map(bank ->
+                converter.mapToDto(bank, BankDto.class)
+        ).toList();
+    }
+}


### PR DESCRIPTION
## Summary
- implement Bank entity, DTO, repository, service and controller
- expose `/api/v1/banks` GET endpoint returning list of banks

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e49931ca48322b7b510785677c5a3